### PR TITLE
Fix a few issues with LinkAdd TunTap creation

### DIFF
--- a/link.go
+++ b/link.go
@@ -3,6 +3,7 @@ package netlink
 import (
 	"fmt"
 	"net"
+	"os"
 )
 
 // Link represents a link device from netlink. Shared link attributes
@@ -284,8 +285,10 @@ type TuntapFlag uint16
 // Tuntap links created via /dev/tun/tap, but can be destroyed via netlink
 type Tuntap struct {
 	LinkAttrs
-	Mode  TuntapMode
-	Flags TuntapFlag
+	Mode   TuntapMode
+	Flags  TuntapFlag
+	Queues int
+	Fds    []*os.File
 }
 
 func (tuntap *Tuntap) Attrs() *LinkAttrs {

--- a/link_test.go
+++ b/link_test.go
@@ -1489,3 +1489,22 @@ func TestLinkByAliasWhenLinkIsNotFound(t *testing.T) {
 		t.Errorf("Error returned expected to of LinkNotFoundError type: %v", err)
 	}
 }
+
+func TestLinkAddDelTuntap(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Tuntap{
+		LinkAttrs: LinkAttrs{Name: "foo"},
+		Mode:      TUNTAP_MODE_TAP})
+}
+
+func TestLinkAddDelTuntapMq(t *testing.T) {
+	tearDown := setUpNetlinkTest(t)
+	defer tearDown()
+
+	testLinkAddDel(t, &Tuntap{
+		LinkAttrs: LinkAttrs{Name: "foo"},
+		Mode:      TUNTAP_MODE_TAP,
+		Queues:    4})
+}


### PR DESCRIPTION
- Set the unix.IFF_NO_PI flag
- Only initialise req object once
- Only set persistence flag once
- Ensure persistence flag is reset and all fds are cleaned up in error cases

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>